### PR TITLE
Bump curv to 0.7 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-party-eddsa"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Omer <omer@kzencorp.com>",
     "Gary <gary@kzencorp.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ authors = [
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-curv = { git = "https://github.com/KZen-networks/curv", tag = "v0.2.0-ed25519", features =  ["ec_ed25519"]}
+curv = { package = "curv-kzen", version = "0.7", default-features = false }
 hex = "0.3.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+
+[features]
+default = ["curv/rust-gmp-kzen"]

--- a/src/protocols/aggsig/test.rs
+++ b/src/protocols/aggsig/test.rs
@@ -17,8 +17,10 @@
 #[cfg(test)]
 mod tests {
     use curv::elliptic::curves::traits::ECPoint;
-    use curv::GE;
+    use curv::elliptic::curves::ed25519::{GE, FE};
+    use curv::BigInt;
     use protocols::aggsig::{test_com, verify, KeyPair, Signature};
+    use curv::arithmetic::Converter;
 
     #[test]
     fn test_ed25519_one_party() {
@@ -196,7 +198,6 @@ mod tests {
     }
 
     use curv::elliptic::curves::traits::ECScalar;
-    use curv::{BigInt, FE};
     use hex::decode;
     #[test]
     fn test_verify_standard_sig() {
@@ -227,7 +228,7 @@ mod tests {
         let s_str = "5a180452743fac943b53728e4cbea288a566ba49f7695808d53b3f9f1cd6ed02";
         let mut s_dec = decode(s_str).unwrap();
         s_dec.reverse();
-        let s_bn = BigInt::from(&s_dec[..]);
+        let s_bn = BigInt::from_bytes(&s_dec[..]);
         let s: FE = ECScalar::from(&s_bn);
 
         let sig = Signature { R, s };

--- a/src/protocols/multisig/mod.rs
+++ b/src/protocols/multisig/mod.rs
@@ -22,7 +22,8 @@ use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
 use curv::cryptographic_primitives::hashing::hash_sha512::HSha512;
 use curv::cryptographic_primitives::hashing::traits::*;
 use curv::elliptic::curves::traits::*;
-use curv::{BigInt, FE, GE};
+use curv::elliptic::curves::ed25519::{GE, FE};
+use curv::BigInt;
 use protocols::multisig;
 
 // TODO: move to a common location to be used by all protocols.
@@ -78,7 +79,7 @@ impl ExpendedKeyPair {
     pub fn create_from_private_key(sk: FE) -> ExpendedKeyPair {
         let ec_point: GE = ECPoint::generator();
         let h = HSha512::create_hash(&vec![&sk.to_big_int()]);
-        let h_vec = BigInt::to_vec(&h);
+        let h_vec = BigInt::to_bytes(&h);
         let mut h_vec_padded = vec![0; 64 - h_vec.len()];  // ensure hash result is padded to 64 bytes
         h_vec_padded.extend_from_slice(&h_vec);
         let mut private_key: [u8; 32] = [0u8; 32];
@@ -90,8 +91,8 @@ impl ExpendedKeyPair {
         private_key[31] |= 64;
         let private_key = &private_key[..private_key.len()];
         let prefix = &prefix[..prefix.len()];
-        let private_key: FE = ECScalar::from(&BigInt::from(private_key));
-        let prefix: FE = ECScalar::from(&BigInt::from(prefix));
+        let private_key: FE = ECScalar::from(&BigInt::from_bytes(private_key));
+        let prefix: FE = ECScalar::from(&BigInt::from_bytes(prefix));
         let public_key = ec_point * &private_key;
         ExpendedKeyPair {
             public_key,

--- a/src/protocols/multisig/test.rs
+++ b/src/protocols/multisig/test.rs
@@ -21,7 +21,9 @@ mod tests {
     use curv::cryptographic_primitives::hashing::merkle_tree::MT256;
     use curv::cryptographic_primitives::hashing::traits::Hash;
     use curv::elliptic::curves::traits::ECScalar;
-    use curv::{BigInt, FE};
+    use curv::elliptic::curves::ed25519::{GE, FE};
+    use curv::BigInt;
+    use curv::arithmetic::Converter;
     use protocols::multisig::{partial_sign, verify, EphKey, Keys, Signature};
 
     #[test]
@@ -33,7 +35,7 @@ mod tests {
 
     fn two_party_key_gen_internal() {
         let message_vec = vec![79, 77, 69, 82];
-        let message_bn = BigInt::from(&message_vec[..]);
+        let message_bn = BigInt::from_bytes(&message_vec[..]);
         let message = HSha256::create_hash(&vec![&message_bn]);
 
         // party1 key gen:
@@ -84,8 +86,8 @@ mod tests {
         let sig = Signature::set_signature(&Xt, &y);
         assert!(verify(&It, &sig, &es).is_ok());
 
-        assert!(MT256::validate_proof(&proof1, root).is_ok());
-        assert!(MT256::validate_proof(&proof2, root).is_ok());
+        assert!(MT256::<GE>::validate_proof(&proof1, root).is_ok());
+        assert!(MT256::<GE>::validate_proof(&proof2, root).is_ok());
     }
 
 }

--- a/src/protocols/thresholdsig/mod.rs
+++ b/src/protocols/thresholdsig/mod.rs
@@ -22,7 +22,8 @@ use curv::cryptographic_primitives::commitments::traits::Commitment;
 use curv::cryptographic_primitives::hashing::hash_sha512::HSha512;
 use curv::cryptographic_primitives::hashing::traits::*;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
-use curv::{BigInt, FE, GE};
+use curv::elliptic::curves::ed25519::{GE, FE};
+use curv::BigInt;
 
 const SECURITY: usize = 256;
 
@@ -87,7 +88,7 @@ impl Keys {
     fn phase1_create_from_private_key_internal(index: usize, sk: &FE) -> Keys {
         let ec_point: GE = ECPoint::generator();
         let h = HSha512::create_hash(&vec![&sk.to_big_int()]);
-        let h_vec = BigInt::to_vec(&h);
+        let h_vec = BigInt::to_bytes(&h);
         let mut h_vec_padded = vec![0; 64 - h_vec.len()];  // ensure hash result is padded to 64 bytes
         h_vec_padded.extend_from_slice(&h_vec);
         let mut private_key: [u8; 32] = [0u8; 32];
@@ -99,8 +100,8 @@ impl Keys {
         private_key[31] |= 64;
         let private_key = &private_key[..private_key.len()];
         let prefix = &prefix[..prefix.len()];
-        let private_key: FE = ECScalar::from(&BigInt::from(private_key));
-        let prefix: FE = ECScalar::from(&BigInt::from(prefix));
+        let private_key: FE = ECScalar::from(&BigInt::from_bytes(private_key));
+        let prefix: FE = ECScalar::from(&BigInt::from_bytes(prefix));
         let public_key = ec_point * &private_key;
 
         Keys {
@@ -128,7 +129,7 @@ impl Keys {
         y_vec: &Vec<GE>,
         bc1_vec: &Vec<KeyGenBroadcastMessage1>,
         parties: &[usize],
-    ) -> Result<(VerifiableSS, Vec<FE>, usize), Error> {
+    ) -> Result<(VerifiableSS<GE>, Vec<FE>, usize), Error> {
         // test length:
         assert_eq!(blind_vec.len(), params.share_count);
         assert_eq!(bc1_vec.len(), params.share_count);
@@ -161,7 +162,7 @@ impl Keys {
         params: &Parameters,
         y_vec: &Vec<GE>,
         secret_shares_vec: &Vec<FE>,
-        vss_scheme_vec: &Vec<VerifiableSS>,
+        vss_scheme_vec: &Vec<VerifiableSS<GE>>,
         index: &usize,
     ) -> Result<SharedKeys, Error> {
         assert_eq!(y_vec.len(), params.share_count);
@@ -207,7 +208,7 @@ impl EphemeralKey {
         // to the nonce
         let r_local = HSha512::create_hash(&[
             &keys.prefix.to_big_int(),
-            &BigInt::from(message),
+            &BigInt::from_bytes(message),
             &FE::new_random().to_big_int(),
         ]);
         let r_i: FE = ECScalar::from(&r_local);
@@ -237,7 +238,7 @@ impl EphemeralKey {
         R_vec: &Vec<GE>,
         bc1_vec: &Vec<KeyGenBroadcastMessage1>,
         parties: &[usize],
-    ) -> Result<(VerifiableSS, Vec<FE>, usize), Error> {
+    ) -> Result<(VerifiableSS<GE>, Vec<FE>, usize), Error> {
         // test length:
         assert!(blind_vec.len() > params.threshold && blind_vec.len() <= params.share_count);
         assert!(bc1_vec.len() > params.threshold && bc1_vec.len() <= params.share_count);
@@ -270,7 +271,7 @@ impl EphemeralKey {
         params: &Parameters,
         R_vec: &Vec<GE>,
         secret_shares_vec: &Vec<FE>,
-        vss_scheme_vec: &Vec<VerifiableSS>,
+        vss_scheme_vec: &Vec<VerifiableSS<GE>>,
         index: &usize,
     ) -> Result<EphemeralSharedKeys, Error> {
         assert!(R_vec.len() > params.threshold && R_vec.len() <= params.share_count);
@@ -316,7 +317,7 @@ impl LocalSig {
         let e_bn = HSha512::create_hash(&[
             &local_ephemaral_key.R.bytes_compressed_to_big_int(),
             &local_private_key.y.bytes_compressed_to_big_int(),
-            &BigInt::from(message),
+            &BigInt::from_bytes(message),
         ]);
         let k: FE = ECScalar::from(&e_bn);
         let gamma_i = r_i + k * s_i;
@@ -329,9 +330,9 @@ impl LocalSig {
     pub fn verify_local_sigs(
         gamma_vec: &Vec<LocalSig>,
         parties_index_vec: &[usize],
-        vss_private_keys: &Vec<VerifiableSS>,
-        vss_ephemeral_keys: &Vec<VerifiableSS>,
-    ) -> Result<(VerifiableSS), Error> {
+        vss_private_keys: &Vec<VerifiableSS<GE>>,
+        vss_ephemeral_keys: &Vec<VerifiableSS<GE>>,
+    ) -> Result<VerifiableSS<GE>, Error> {
         //parties_index_vec is a vector with indices of the parties that are participating and provided gamma_i for this step
         // test that enough parties are in this round
         assert!(parties_index_vec.len() > vss_private_keys[0].parameters.threshold);
@@ -380,7 +381,7 @@ impl LocalSig {
 
 impl Signature {
     pub fn generate(
-        vss_sum_local_sigs: &VerifiableSS,
+        vss_sum_local_sigs: &VerifiableSS<GE>,
         local_sig_vec: &Vec<LocalSig>,
         parties_index_vec: &[usize],
         R: GE,
@@ -400,7 +401,7 @@ impl Signature {
         let e_bn = HSha512::create_hash(&[
             &self.R.bytes_compressed_to_big_int(),
             &pubkey_y.bytes_compressed_to_big_int(),
-            &BigInt::from(message),
+            &BigInt::from_bytes(message),
         ]);
 
         let e: FE = ECScalar::from(&e_bn);

--- a/src/protocols/thresholdsig/test.rs
+++ b/src/protocols/thresholdsig/test.rs
@@ -13,7 +13,7 @@
 #[cfg(test)]
 mod tests {
     use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
-    use curv::{FE, GE};
+    use curv::elliptic::curves::ed25519::{GE, FE};
     use protocols::thresholdsig::*;
 
     #[test]
@@ -132,7 +132,7 @@ mod tests {
         t: usize,
         n: usize,
         parties: &[usize],
-    ) -> (Vec<Keys>, Vec<SharedKeys>, GE, Vec<VerifiableSS>) {
+    ) -> (Vec<Keys>, Vec<SharedKeys>, GE, Vec<VerifiableSS<GE>>) {
         let parames = Parameters {
             threshold: t,
             share_count: n.clone(),
@@ -209,7 +209,7 @@ mod tests {
         Vec<EphemeralKey>,
         Vec<EphemeralSharedKeys>,
         GE,
-        Vec<VerifiableSS>,
+        Vec<VerifiableSS<GE>>,
     ) {
         let parames = Parameters {
             threshold: t,


### PR DESCRIPTION
I bumped `curv` version, fixed code changes and bumped this crate's version,
I also added a default feature (`default = ["curv/rust-gmp-kzen"]`), please tell me if that's not the right way to do it